### PR TITLE
[ptf-948] Zero gaspi - Problèmes d'affichage pour certains utilisateurs

### DIFF
--- a/components/List.vue
+++ b/components/List.vue
@@ -59,7 +59,7 @@ export default class List extends Vue {
                 const scrollPosition = window.scrollY || window.pageYOffset || document.body.scrollTop +
                     (document.documentElement && document.documentElement.scrollTop || 0);
 
-                if (document.body.offsetHeight <= windowHeight + scrollPosition) {
+                if (document.body.offsetHeight <= windowHeight + scrollPosition + 1) {
                     this.page++;
                     this.loadUsingApi();
                 }


### PR DESCRIPTION
Lorsqu'il y a un zoom, `scrollPosition` peut ne pas être un nombre de pixel entier ce qui fait que la somme n'atteint jamais la valeur du bas de la page.
On ajoute 1 pour forcer la supériorité lorsqu'on arrive en bas de page.